### PR TITLE
Fix empty coordinates check

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -41,7 +41,7 @@ class Board
   end
 
   def empty_placement(coordinates_array)
-    coordinates_array.any? do |coord|
+    coordinates_array.all? do |coord|
       cells[coord].empty?
     end
   end


### PR DESCRIPTION
Computer was overlapping ships, and I found that the empty_placement method in the board class was returning true if `any` of the coordinates were empty and it needed to check if `all` of the coordinates were empty